### PR TITLE
google drive folder for CfD embed in site

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,6 +187,14 @@
             </a>
           </div>
         </div>
+        <div class="row">
+          <div class="col-md-12">
+            <h2>Google Drive</h2>
+            <div class="text-center">
+                <iframe src="https://drive.google.com/embeddedfolderview?id=0B15HLk4_JV3nWjkyOGtFUmhKZDQ#list" width="100%" height="600" frameborder="0"></iframe>
+            </div>
+          </div>
+        </div>
 
 
     </section>


### PR DESCRIPTION
I embed the shared google drive folder in to the CfD site to make it easier to access this resource. This may be a resolution to this issue https://github.com/codefordenver/code-for-denver-site/issues/24

- Connects to #24