### PR TITLE
Fix content size when directly loading non-root page

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,6 +4,7 @@
         <meta charset="utf-8">
         <!-- <title>Page Not Found :(</title> -->
         <title>Code for Denver</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <style>
             /*::-moz-selection {


### PR DESCRIPTION
When a page is loaded directly on a mobile device the size is currently incorrect. This pull request fixes that.