### PR TITLE
Fix Code for America API url

### DIFF
--- a/src/components/segments/MeetupsContainer.js
+++ b/src/components/segments/MeetupsContainer.js
@@ -15,7 +15,7 @@ class MeetupsContainer extends React.Component {
 
 
   componentWillMount() {
-    const url = "https://codeforamerica.org/api/organizations/Code-for-Denver";
+    const url = 'https://codeforamerica-api.herokuapp.com/api/organizations/Code-for-Denver';
     const xmlhttp = new XMLHttpRequest();
 
     xmlhttp.onreadystatechange = () => {
@@ -33,14 +33,14 @@ class MeetupsContainer extends React.Component {
       }
     }
 
-    xmlhttp.open("GET", url, true);
+    xmlhttp.open('GET', url, true);
     xmlhttp.send();
   }
 
 	render() {
 		return (
       <MeetupDate {...this.state.meetupProps} />
-    ) 
+    )
 	}
 }
 


### PR DESCRIPTION
This PR closes #287 

#### What does this PR do?

Changes the url from which we query the Code for America API, because the previous url is broken. See https://github.com/opensmc/opensmc.github.io/pull/40 for context

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](http://i.giphy.com/l3V0AYbDjTVOO4zF6.gif)
