### PR TITLE
Remove homepage link to NDoCH resources

### DIFF
--- a/src/components/pages/WhoWeAre.js
+++ b/src/components/pages/WhoWeAre.js
@@ -17,13 +17,6 @@ const WhoWeAre = () => (
     <Interested />
     <div className='body-content-wrapper'>
       <div className='body-content'>
-        <div className="temp-resource-link">
-          <h3>
-            <a href="/NDoCH_2016">
-              National Day of Civic Hacking Resources
-            </a>
-          </h3>
-        </div>
         <WhoWeAreContent />
         <VimeoVideo />
         <section className="standard getconnected">

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -833,12 +833,3 @@ blockquote
   height: 1px;
   margin-top: 40px;
 }
-
-.temp-resource-link {
-  text-align: center;
-  padding-top: 2em;
-}
-
-.temp-resource-link h3 {
-  margin: 0;
-}


### PR DESCRIPTION
#### What does this PR do?

Removes the temporary link that was added to the homepage of the website for national day of civic hacking 2016 resources.

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](http://i.giphy.com/OlEot6LMydJfO.gif)

